### PR TITLE
Modified dockerfile for singularity compatability.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,8 @@ ENV PATH="/opt/conda/envs/molkart_local/bin:$PATH"
 # Set the default shell to bash (already the default)
 SHELL ["/bin/bash", "-c"]
 
-# Activate the conda environment by default when starting a shell
-# This will ensure that the conda environment's python is used
-RUN echo "source activate molkart_local" > ~/.bashrc
-ENV BASH_ENV ~/.bashrc
+RUN echo "source activate molkart_local" > /bashrc
+ENV BASH_ENV /bashrc
 
 # Set the working directory
 WORKDIR /local


### PR DESCRIPTION
The previous version docker containing was mounting $HOME/.bashrc which was causing issues when mounting $HOME in certain singularity nextflow processes. The fix writes the activation of the conda environment to an arbitrary `/bashrc`/ within the container, not touching anything in the home folder. This should fix the issue.